### PR TITLE
Add timestamp to block generated from header

### DIFF
--- a/grpc/execution/server.go
+++ b/grpc/execution/server.go
@@ -269,5 +269,8 @@ func ethHeaderToExecutionBlock(header *types.Header) (*astriaPb.Block, error) {
 		Number:          uint32(header.Number.Int64()),
 		Hash:            header.Hash().Bytes(),
 		ParentBlockHash: header.ParentHash.Bytes(),
+		Timestamp: &timestamppb.Timestamp{
+			Seconds: int64(header.Time),
+		},
 	}, nil
 }


### PR DESCRIPTION
We weren't sending this and it now generates errors, was always a missed attribute