### PR TITLE
feat: implement `DepositTx` type and handling

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -26,7 +26,6 @@ import (
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -365,7 +364,6 @@ func (st *StateTransition) preCheck() error {
 func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// if this is a deposit tx, we only need to mint funds and no gas is used.
 	if st.msg.IsDepositTx {
-		log.Info("executing deposit tx", "from", st.msg.From, "value", st.msg.Value)
 		st.state.AddBalance(st.msg.From, st.msg.Value)
 		return &ExecutionResult{
 			UsedGas:    0,

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -334,9 +334,9 @@ func New(config Config, chain BlockChain) *BlobPool {
 	}
 }
 
-func (p *BlobPool) SetAstriaOrdered(rawTxs [][]byte)   {}
-func (p *BlobPool) ClearAstriaOrdered()                {}
-func (p *BlobPool) AstriaOrdered() *types.Transactions { return &types.Transactions{} }
+func (p *BlobPool) SetAstriaOrdered(types.Transactions) {}
+func (p *BlobPool) ClearAstriaOrdered()                 {}
+func (p *BlobPool) AstriaOrdered() *types.Transactions  { return &types.Transactions{} }
 
 // Filter returns whether the given transaction can be consumed by the blob pool.
 func (p *BlobPool) Filter(tx *types.Transaction) bool {

--- a/core/txpool/subpool.go
+++ b/core/txpool/subpool.go
@@ -138,7 +138,7 @@ type SubPool interface {
 	// identified by their hashes.
 	Status(hash common.Hash) TxStatus
 
-	SetAstriaOrdered(rawTxs [][]byte)
+	SetAstriaOrdered(types.Transactions)
 	ClearAstriaOrdered()
 	AstriaOrdered() *types.Transactions
 }

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -261,9 +261,9 @@ func (p *TxPool) Get(hash common.Hash) *types.Transaction {
 }
 
 // Get returns a transaction if it is contained in the pool, or nil otherwise.
-func (p *TxPool) SetAstriaOrdered(rawTxs [][]byte) {
+func (p *TxPool) SetAstriaOrdered(txs types.Transactions) {
 	for _, subpool := range p.subpools {
-		subpool.SetAstriaOrdered(rawTxs)
+		subpool.SetAstriaOrdered(txs)
 	}
 }
 

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -90,23 +90,25 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if tx.GasFeeCapIntCmp(tx.GasTipCap()) < 0 {
 		return core.ErrTipAboveFeeCap
 	}
-	// Make sure the transaction is signed properly
-	if _, err := types.Sender(signer, tx); err != nil {
-		return ErrInvalidSender
-	}
-	// Ensure the transaction has more gas than the bare minimum needed to cover
-	// the transaction metadata
-	intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, opts.Config.IsIstanbul(head.Number), opts.Config.IsShanghai(head.Number, head.Time))
-	if err != nil {
-		return err
-	}
-	if tx.Gas() < intrGas {
-		return fmt.Errorf("%w: needed %v, allowed %v", core.ErrIntrinsicGas, intrGas, tx.Gas())
-	}
-	// Ensure the gasprice is high enough to cover the requirement of the calling
-	// pool and/or block producer
-	if tx.GasTipCapIntCmp(opts.MinTip) < 0 {
-		return fmt.Errorf("%w: tip needed %v, tip permitted %v", ErrUnderpriced, opts.MinTip, tx.GasTipCap())
+	if tx.Type() != types.DepositTxType {
+		// Make sure the transaction is signed properly
+		if _, err := types.Sender(signer, tx); err != nil {
+			return ErrInvalidSender
+		}
+		// Ensure the transaction has more gas than the bare minimum needed to cover
+		// the transaction metadata
+		intrGas, err := core.IntrinsicGas(tx.Data(), tx.AccessList(), tx.To() == nil, true, opts.Config.IsIstanbul(head.Number), opts.Config.IsShanghai(head.Number, head.Time))
+		if err != nil {
+			return err
+		}
+		if tx.Gas() < intrGas {
+			return fmt.Errorf("%w: needed %v, allowed %v", core.ErrIntrinsicGas, intrGas, tx.Gas())
+		}
+		// Ensure the gasprice is high enough to cover the requirement of the calling
+		// pool and/or block producer
+		if tx.GasTipCapIntCmp(opts.MinTip) < 0 {
+			return fmt.Errorf("%w: tip needed %v, tip permitted %v", ErrUnderpriced, opts.MinTip, tx.GasTipCap())
+		}
 	}
 	// Ensure blob transactions have valid commitments
 	if tx.Type() == types.BlobTxType {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -11,8 +11,6 @@ import (
 var _ TxData = &DepositTx{}
 
 type DepositTx struct {
-	// // SourceHash uniquely identifies the source of the deposit
-	// SourceHash common.Hash
 	// the address of the account that initiated the deposit
 	From common.Address
 	// value to be minted to `From`
@@ -21,7 +19,6 @@ type DepositTx struct {
 	Gas uint64
 }
 
-// copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *DepositTx) copy() TxData {
 	cpy := &DepositTx{
 		From:  tx.From,
@@ -34,7 +31,6 @@ func (tx *DepositTx) copy() TxData {
 	return cpy
 }
 
-// accessors for innerTx.
 func (tx *DepositTx) txType() byte           { return DepositTxType }
 func (tx *DepositTx) chainID() *big.Int      { return common.Big0 }
 func (tx *DepositTx) accessList() AccessList { return nil }
@@ -56,7 +52,7 @@ func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
 }
 
 func (tx *DepositTx) setSignatureValues(chainID, v, r, s *big.Int) {
-	// this is a noop for deposit transactions
+	// noop
 }
 
 func (tx *DepositTx) encode(b *bytes.Buffer) error {

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -1,0 +1,68 @@
+package types
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+var _ TxData = &DepositTx{}
+
+type DepositTx struct {
+	// // SourceHash uniquely identifies the source of the deposit
+	// SourceHash common.Hash
+	// the address of the account that initiated the deposit
+	From common.Address
+	// value to be minted to `From`
+	Value *big.Int
+	// gas limit
+	Gas uint64
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *DepositTx) copy() TxData {
+	cpy := &DepositTx{
+		From:  tx.From,
+		Value: new(big.Int),
+		Gas:   tx.Gas,
+	}
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *DepositTx) txType() byte           { return DepositTxType }
+func (tx *DepositTx) chainID() *big.Int      { return common.Big0 }
+func (tx *DepositTx) accessList() AccessList { return nil }
+func (tx *DepositTx) data() []byte           { return nil }
+func (tx *DepositTx) gas() uint64            { return tx.Gas }
+func (tx *DepositTx) gasFeeCap() *big.Int    { return new(big.Int) }
+func (tx *DepositTx) gasTipCap() *big.Int    { return new(big.Int) }
+func (tx *DepositTx) gasPrice() *big.Int     { return new(big.Int) }
+func (tx *DepositTx) value() *big.Int        { return tx.Value }
+func (tx *DepositTx) nonce() uint64          { return 0 }
+func (tx *DepositTx) to() *common.Address    { return nil }
+
+func (tx *DepositTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	return dst.Set(new(big.Int))
+}
+
+func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
+	return common.Big0, common.Big0, common.Big0
+}
+
+func (tx *DepositTx) setSignatureValues(chainID, v, r, s *big.Int) {
+	// this is a noop for deposit transactions
+}
+
+func (tx *DepositTx) encode(b *bytes.Buffer) error {
+	return rlp.Encode(b, tx)
+}
+
+func (tx *DepositTx) decode(input []byte) error {
+	return rlp.DecodeBytes(input, tx)
+}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -204,7 +204,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, BlobTxType:
+	case DynamicFeeTxType, AccessListTxType, BlobTxType, DepositTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -45,6 +45,7 @@ const (
 	AccessListTxType = 0x01
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
+	DepositTxType    = 0x04
 )
 
 // Transaction is an Ethereum transaction.
@@ -67,7 +68,7 @@ func NewTx(inner TxData) *Transaction {
 
 // TxData is the underlying data of a transaction.
 //
-// This is implemented by DynamicFeeTx, LegacyTx and AccessListTx.
+// This is implemented by DynamicFeeTx, LegacyTx, AccessListTx and DepositTx.
 type TxData interface {
 	txType() byte // returns the type ID
 	copy() TxData // creates a deep copy and initializes all fields
@@ -202,6 +203,8 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		inner = new(DynamicFeeTx)
 	case BlobTxType:
 		inner = new(BlobTx)
+	case DepositTxType:
+		inner = new(DepositTx)
 	default:
 		return nil, ErrTxTypeNotSupported
 	}

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -99,6 +99,17 @@ type TxData interface {
 	decode([]byte) error
 }
 
+// From returns the sender of the transaction
+// only for deposit transactions.
+func (tx *Transaction) From() common.Address {
+	if tx.Type() != DepositTxType {
+		return common.Address{}
+	}
+
+	deposit := tx.inner.(*DepositTx)
+	return deposit.From
+}
+
 // EncodeRLP implements rlp.Encoder
 func (tx *Transaction) EncodeRLP(w io.Writer) error {
 	if tx.Type() == LegacyTxType {

--- a/genesis.json
+++ b/genesis.json
@@ -14,15 +14,16 @@
         "shanghaiTime": 0,
         "terminalTotalDifficulty": 0,
         "terminalTotalDifficultyPassed": true,
-        "ethash": {}
+        "ethash": {},
+        "astriaRollupName": "astria",
+        "astriaOverrideGenesisExtraData": true,
+        "astriaSequencerInitialHeight": 2,
+        "astriaCelestiaInitialHeight": 2,
+        "astriaCelestiaHeightVariance": 10
     },
     "difficulty": "10000000",
     "gasLimit": "8000000",
     "alloc": {
         "0x46B77EFDFB20979E1C29ec98DcE73e3eCbF64102": { "balance": "300000000000000000000" }
-    },
-    "astriaOverrideGenesisExtraData": true,
-    "astriaSequencerInitialHeight": 1,
-    "astriaDataAvailabilityInitialHeight": 1,
-    "astriaDataAvailabilityHeightVariance": 50
+    }
 }

--- a/grpc/execution/server.go
+++ b/grpc/execution/server.go
@@ -172,12 +172,9 @@ func (s *ExecutionServiceServerV1Alpha2) ExecuteBlock(ctx context.Context, req *
 		return nil, status.Error(codes.FailedPrecondition, "Block can only be created on top of soft block.")
 	}
 
-	// Filter out any Deposit txs since we don't currently support them
 	txsToProcess := types.Transactions{}
 	for _, tx := range req.Transactions {
-		log.Info("Processing tx", "tx", tx)
 		if deposit := tx.GetDeposit(); deposit != nil {
-			log.Info("Deposit tx found", "tx", tx)
 			address := common.HexToAddress(deposit.DestinationChainAddress)
 			txdata := types.DepositTx{
 				From:  address,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -745,9 +745,6 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 	if tx.Type() == types.BlobTxType {
 		return w.commitBlobTransaction(env, tx)
 	}
-	if tx.Type() == types.DepositTxType {
-		log.Warn("committing deposit tx")
-	}
 	receipt, err := w.applyTransaction(env, tx)
 	if err != nil {
 		return nil, err
@@ -831,9 +828,6 @@ func (w *worker) commitAstriaTransactions(env *environment, txs *types.Transacti
 		env.state.SetTxContext(tx.Hash(), env.tcount)
 
 		logs, err := w.commitTransaction(env, tx)
-		if err != nil {
-			log.Error("Failed to commit transaction", "hash", tx.Hash(), "err", err)
-		}
 		switch {
 		case errors.Is(err, core.ErrGasLimitReached):
 			// Pop the current out-of-gas transaction without shifting in the next from the account
@@ -1072,7 +1066,6 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 func (w *worker) fillAstriaTransactions(interrupt *atomic.Int32, env *environment) error {
 	// Use pre ordered array of txs
 	astriaTxs := w.eth.TxPool().AstriaOrdered()
-	log.Warn("Astria txs", "txs", astriaTxs)
 	if len(*astriaTxs) > 0 {
 		if err := w.commitAstriaTransactions(env, astriaTxs, interrupt); err != nil {
 			return err


### PR DESCRIPTION
- implement `DepositTx` type
- update state transition to mint funds to the sender of the `DepositTx` (from address)
- ignoring signature checks for `DepositTx` as they're unsigned and inherent to rollup consensus