### PR TITLE
add bridge address and asset IDs to genesis and check during execution

### DIFF
--- a/genesis.json
+++ b/genesis.json
@@ -19,7 +19,9 @@
         "astriaOverrideGenesisExtraData": true,
         "astriaSequencerInitialHeight": 2,
         "astriaCelestiaInitialHeight": 2,
-        "astriaCelestiaHeightVariance": 10
+        "astriaCelestiaHeightVariance": 10,
+        "astriaBridgeAddresses": [],
+        "astriaBridgeAllowedAssetDenom": "nria"
     },
     "difficulty": "10000000",
     "gasLimit": "8000000",

--- a/params/config.go
+++ b/params/config.go
@@ -337,12 +337,14 @@ type ChainConfig struct {
 	IsDevMode bool          `json:"isDev,omitempty"`
 
 	// Astria Specific Configuration
-	AstriaOverrideGenesisExtraData bool          `json:"astriaOverrideGenesisExtraData,omitempty"`
-	AstriaExtraDataOverride        hexutil.Bytes `json:"astriaExtraDataOverride,omitempty"`
-	AstriaRollupName               string        `json:"astriaRollupName,omitempty"`
-	AstriaSequencerInitialHeight   uint32        `json:"astriaSequencerInitialHeight"`
-	AstriaCelestiaInitialHeight    uint32        `json:"astriaCelestiaInitialHeight"`
-	AstriaCelestiaHeightVariance   uint32        `json:"astriaCelestiaHeightVariance,omitempty"`
+	AstriaOverrideGenesisExtraData bool            `json:"astriaOverrideGenesisExtraData,omitempty"`
+	AstriaExtraDataOverride        hexutil.Bytes   `json:"astriaExtraDataOverride,omitempty"`
+	AstriaRollupName               string          `json:"astriaRollupName,omitempty"`
+	AstriaSequencerInitialHeight   uint32          `json:"astriaSequencerInitialHeight"`
+	AstriaCelestiaInitialHeight    uint32          `json:"astriaCelestiaInitialHeight"`
+	AstriaCelestiaHeightVariance   uint32          `json:"astriaCelestiaHeightVariance,omitempty"`
+	AstriaBridgeAddresses          []hexutil.Bytes `json:"astriaBridgeAddresses,omitempty"`
+	AstriaBridgeAllowedAssetDenom  string          `json:"astriaBridgeAllowedAssetDenom,omitempty"`
 }
 
 func (c *ChainConfig) AstriaExtraData() []byte {
@@ -356,6 +358,8 @@ func (c *ChainConfig) AstriaExtraData() []byte {
 		c.AstriaSequencerInitialHeight,
 		c.AstriaCelestiaInitialHeight,
 		c.AstriaCelestiaHeightVariance,
+		c.AstriaBridgeAddresses,
+		c.AstriaBridgeAllowedAssetDenom,
 	})
 	if uint64(len(extra)) > MaximumExtraDataSize {
 		log.Warn("Miner extra data exceed limit", "extra", hexutil.Bytes(extra), "limit", MaximumExtraDataSize)


### PR DESCRIPTION
`astriaBridgeAddresses` should be a list of sequencer addresses (hex encoded with 0x prefix).

 `astriaBridgeAllowedAssetDenom` should be the denom (not ID) of the asset allowed to be bridged over (as this will become the minted native token, there can only be one asset). examples: `nria`, `channel-0/transfer/tia`

deposits that do not have the right bridge address or asset denom are ignored.